### PR TITLE
Don't use git "-C" flag

### DIFF
--- a/first_build.sh
+++ b/first_build.sh
@@ -6,9 +6,11 @@ source .env
 # init Combine app submodule and use localsettings docker template
 git submodule init
 git submodule update
-git -C combine/combine fetch
-git -C combine/combine checkout $COMBINE_BRANCH
-git -C combine/combine pull
+cd combine/combine
+git fetch
+git checkout $COMBINE_BRANCH
+git  pull
+cd ../../
 cp ./combine/combine/combine/localsettings.py.docker ./combine/combine/combine/localsettings.py
 
 # build images

--- a/first_build.sh
+++ b/first_build.sh
@@ -10,9 +10,8 @@ cd combine/combine
 git fetch
 git checkout $COMBINE_BRANCH
 git  pull
+cp ./combine/localsettings.py.docker ./combine/localsettings.py
 cd ../../
-cp ./combine/combine/combine/localsettings.py.docker ./combine/combine/combine/localsettings.py
-
 # build images
 docker volume rm combine_python_env hadoop_binaries spark_binaries livy_binaries combine_tmp
 docker-compose build

--- a/update_build.sh
+++ b/update_build.sh
@@ -9,9 +9,11 @@ docker-compose down
 # init Combine app submodule and use localsettings docker template
 git submodule init
 git submodule update
-git -C combine/combine fetch
-git -C combine/combine checkout $COMBINE_BRANCH
-git -C combine/combine pull
+cd combine/combine
+git fetch
+git $COMBINE_BRANCH
+git pull
+cd ../../
 
 # build images
 docker volume rm combine_python_env hadoop_binaries spark_binaries livy_binaries combine_tmp

--- a/update_build.sh
+++ b/update_build.sh
@@ -11,7 +11,7 @@ git submodule init
 git submodule update
 cd combine/combine
 git fetch
-git $COMBINE_BRANCH
+git checkout $COMBINE_BRANCH
 git pull
 cd ../../
 


### PR DESCRIPTION
Git -C was introduced in git 1.8.5, but the latets on current CentOS (and similar) is 1.8.3.1

Replaces calls to -C with `cd` into that directory and then `cd` back to
original directory