### PR TITLE
Fix while loop test

### DIFF
--- a/combine/combine_db_prepare.sh
+++ b/combine/combine_db_prepare.sh
@@ -2,7 +2,7 @@
 
 # run combine migrations
 echo "waiting for MySQL container to be ready..."
-while [ ! mysqladmin ping -h "mysql" --port=3307 -pcombine --silent ]; do
+while [ ! "`mysqladmin ping -h mysql --port=3307 -pcombine --silent`" ]; do
     echo "waiting..."
     sleep 1
 done


### PR DESCRIPTION
The while loop testing the readiness of MySQL is waiting on output from:
````
   mysqladmin ping -h "mysql" --port=3307 -pcombine --silent
````
Output will either be nothing (if it is not ready) or the string "mysqld is alive".  Surrounding the above (slightly edited) with double quotes & back ticks:
````
   "`mysqladmin ping -h mysql --port=3307 -pcombine --silent`"
````
allows the ! to operate on the entire return value "mysqld is alive", whereas not doing so results in the error:
````
   waiting for MySQL container to be ready...
   ./combine_db_prepare.sh: line 5: [: too many arguments
````