### PR TITLE
Give hadoop a way to find its namenode

### DIFF
--- a/nginx/nginx.conf.template
+++ b/nginx/nginx.conf.template
@@ -49,6 +49,10 @@ http {
       proxy_pass http://hadoop-datanode:50075/;
     }
 
+    location /hadoop-namenode {
+      proxy_pass http://hadoop-namenode:8020/;
+    }
+
     location /spark/ {
       proxy_pass http://livy:4040/jobs/;
     }


### PR DESCRIPTION
It's possible that we also need to add the following lines to `hadoop/hdfs-site.xml`:
```
<property>                                                           
    <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
                                                                     
    <value>false</value>                                             
</property>                                                          
```

....but this change is definitely necessary.
